### PR TITLE
⚡ Replace StringBuffer with StringBuilder in Lexers and Utils

### DIFF
--- a/src/main/java/app/freerouting/io/specctra/parser/SpecctraDsnStreamReader.java
+++ b/src/main/java/app/freerouting/io/specctra/parser/SpecctraDsnStreamReader.java
@@ -245,7 +245,7 @@ public class SpecctraDsnStreamReader implements IJFlexScanner {
   private static final int[] ZZ_ATTRIBUTE = zzUnpackAttribute();
   public static String scope_identifier = "";
   public static NumberFormat nf;
-  /* user code: */ StringBuffer stringBuffer = new StringBuffer();
+  /* user code: */ StringBuilder stringBuffer = new StringBuilder();
   /**
    * the input device
    */

--- a/src/main/java/app/freerouting/io/specctra/parser/SpecctraFileDescription.flex
+++ b/src/main/java/app/freerouting/io/specctra/parser/SpecctraFileDescription.flex
@@ -11,7 +11,7 @@ package designformats.specctra;
 /* %debug */
 
 %{
-  StringBuffer string = new StringBuffer();
+  StringBuilder string = new StringBuilder();
 %}
 
 LineTerminator = \r|\n|\r\n

--- a/src/main/java/app/freerouting/util/TextManager.java
+++ b/src/main/java/app/freerouting/util/TextManager.java
@@ -214,7 +214,7 @@ public class TextManager {
   public static String unescapeUnicode(String text) {
     Pattern pattern = Pattern.compile("\\\\u(\\p{XDigit}{4})");
     Matcher matcher = pattern.matcher(text);
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
 
     while (matcher.find()) {
       String hexCode = matcher.group(1);

--- a/src_v19/main/java/app/freerouting/designforms/specctra/SpecctraDsnFileReader.java
+++ b/src_v19/main/java/app/freerouting/designforms/specctra/SpecctraDsnFileReader.java
@@ -524,7 +524,7 @@ class SpecctraDsnFileReader implements IJFlexScanner {
   private static final int[] ZZ_ATTRIBUTE = zzUnpackAttribute();
   public static NumberFormat nf;
   /* user code: */
-  StringBuffer stringBuffer = new StringBuffer();
+  StringBuilder stringBuffer = new StringBuilder();
   /** the input device */
   private java.io.Reader zzReader;
   /** the current state of the DFA */

--- a/src_v19/main/java/app/freerouting/designforms/specctra/SpecctraFileDescription.flex
+++ b/src_v19/main/java/app/freerouting/designforms/specctra/SpecctraFileDescription.flex
@@ -11,7 +11,7 @@ package designformats.specctra;
 /* %debug */
 
 %{
-  StringBuffer string = new StringBuffer();
+  StringBuilder string = new StringBuilder();
 %}
 
 LineTerminator = \r|\n|\r\n


### PR DESCRIPTION
💡 **What:** Replaced \`StringBuffer\` with \`StringBuilder\` in \`SpecctraDsnFileReader.java\`, \`SpecctraDsnStreamReader.java\`, \`TextManager.java\` and the corresponding JFlex specification files (\`SpecctraFileDescription.flex\`).
🎯 **Why:** \`StringBuilder\` is faster than \`StringBuffer\` as it avoids synchronization overhead. Since these fields are private to the lexer or used within local utility methods, they are accessed sequentially by a single thread, making synchronization unnecessary.
📊 **Measured Improvement:** Direct performance measurement was impractical due to a project-wide Gradle toolchain configuration issue (\`NoSuchFieldError: JvmVendorSpec IBM_SEMERU\`) which prevented running benchmarks or the full test suite in the current environment. However, this is a standard Java performance best practice with a guaranteed positive (though likely small per call) impact on CPU efficiency and reduced contention.

---
*PR created automatically by Jules for task [16261331895529931645](https://jules.google.com/task/16261331895529931645) started by @ceoloide*