### PR TITLE
⚡ Replace StringBuffer with StringBuilder in SpecctraDsnStreamReader

### DIFF
--- a/src/main/java/app/freerouting/io/specctra/parser/SpecctraDsnStreamReader.java
+++ b/src/main/java/app/freerouting/io/specctra/parser/SpecctraDsnStreamReader.java
@@ -245,7 +245,7 @@ public class SpecctraDsnStreamReader implements IJFlexScanner {
   private static final int[] ZZ_ATTRIBUTE = zzUnpackAttribute();
   public static String scope_identifier = "";
   public static NumberFormat nf;
-  /* user code: */ StringBuffer stringBuffer = new StringBuffer();
+  /* user code: */ StringBuilder stringBuffer = new StringBuilder();
   /**
    * the input device
    */

--- a/src/main/java/app/freerouting/io/specctra/parser/SpecctraFileDescription.flex
+++ b/src/main/java/app/freerouting/io/specctra/parser/SpecctraFileDescription.flex
@@ -11,7 +11,7 @@ package designformats.specctra;
 /* %debug */
 
 %{
-  StringBuffer string = new StringBuffer();
+  StringBuilder string = new StringBuilder();
 %}
 
 LineTerminator = \r|\n|\r\n

--- a/src/main/java/app/freerouting/util/TextManager.java
+++ b/src/main/java/app/freerouting/util/TextManager.java
@@ -214,7 +214,7 @@ public class TextManager {
   public static String unescapeUnicode(String text) {
     Pattern pattern = Pattern.compile("\\\\u(\\p{XDigit}{4})");
     Matcher matcher = pattern.matcher(text);
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
 
     while (matcher.find()) {
       String hexCode = matcher.group(1);


### PR DESCRIPTION
💡 **What:** Replaced all instances of `StringBuffer` with `StringBuilder` in `SpecctraDsnStreamReader.java`, its JFlex specification `SpecctraFileDescription.flex`, and `TextManager.java`.

🎯 **Why:** `StringBuilder` is more efficient than `StringBuffer` as it avoids the overhead of synchronization. Since these classes are used in a single-threaded context (lexing and text management), `StringBuilder` provides a performance boost without any risk to thread safety.

📊 **Measured Improvement:** I was unable to establish a meaningful performance baseline or measure the improvement directly due to environment-specific Gradle toolchain issues preventing the execution of benchmarks and tests. However, this is a standard performance optimization in Java for non-thread-safe use cases.

---
*PR created automatically by Jules for task [11931545039058272108](https://jules.google.com/task/11931545039058272108) started by @ceoloide*